### PR TITLE
Simplifications des conditionnelles

### DIFF
--- a/src/main/java/co/simplon/prairie/FizzBuzz.java
+++ b/src/main/java/co/simplon/prairie/FizzBuzz.java
@@ -34,20 +34,17 @@ public class FizzBuzz {
  
         if (entier == 0)
         {
-            return Integer.toString(0);
+            return "0";
         }
-        else if (entier % 3 == 0)
+        if (entier % 3 == 0)
         {
           return "Fizz";
         }
-        else if (entier % 5 == 0)
+        if (entier % 5 == 0)
         {
           return "Buzz";
         }
-        else
-        {
-            return Integer.toString(entier);
-        }
+        return Integer.toString(entier);
     }
 
 }


### PR DESCRIPTION
Le else n'est pas indispensable à partir du moment où on retourne directement le résultat via une instruction return.
